### PR TITLE
Add simulated cdn functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ cython_debug/
 
 # Storage folder
 /storage/
+/cdn_storage/

--- a/app.py
+++ b/app.py
@@ -21,6 +21,7 @@ from multiprocessing import Manager
 from flask import Flask, jsonify, request
 from vm_simulator import start_vm, stop_vm, monitor_vm, delete_vm, display_vms
 from storage import create_bucket, upload_file, delete_file, delete_bucket
+from cdn import upload_to_origin, serve_from_nearest_edge
 
 app = Flask(__name__)
 
@@ -34,6 +35,8 @@ def home():
         JSON response with a message.
     """
     return jsonify({"message": "Cloud Simulator is running!"})
+
+# Virtual Machine Routes
 
 @app.route('/start_vm/<int:vm_id>', methods=['POST'])
 def start_vm_route(vm_id):
@@ -91,6 +94,9 @@ def display_vms_route():
     """
     return jsonify(display_vms(vms))
 
+
+# Storage Routes
+
 @app.route('/create_bucket/<bucket_name>', methods=['POST'])
 def create_storage_bucket(bucket_name):
     """
@@ -140,6 +146,34 @@ def delete_storage_bucket(bucket_name):
         JSON response with the result of the operation.
     """
     result = delete_bucket(bucket_name)
+    return jsonify(result)
+
+# CDN Routes
+
+@app.route('/upload_to_origin/<file_name>', methods=['POST'])
+def upload_to_origin_server(file_name):
+    """
+    Route to upload a file to the origin server.
+    Args:
+        file_name (str): The name of the file to upload.
+    Returns:
+        JSON response with the result of the operation.
+    """
+    content = request.json.get('content')
+    result = upload_to_origin(file_name, content)
+    return jsonify(result)
+
+@app.route('/get_file/<file_name>/<int:user_location>', methods=['GET'])
+def get_file_from_nearest_edge(file_name, user_location):
+    """
+    Route to serve a file from the nearest edge server based on the user's location.
+    Args:
+        file_name (str): The name of the file to serve.
+        user_location (int): The location of the user.
+    Returns:
+        JSON response with the content of the file and the server it was served from.
+    """
+    result = serve_from_nearest_edge(file_name, user_location)
     return jsonify(result)
 
 if __name__ == '__main__':

--- a/cdn.py
+++ b/cdn.py
@@ -1,0 +1,81 @@
+"""
+CDN Module
+
+This module simulates a simple Content Delivery Network (CDN) with basic functionalities 
+such as uploading files to the origin server, replicating files to edge servers, and 
+serving files from the nearest edge server.
+
+Functions:
+    upload_to_origin(file_name, content):
+        Uploads a file to the origin server and replicates it to all edge servers.
+    replicate_to_edges(file_name):
+        Replicates a file from the origin server to all edge servers.
+    serve_from_nearest_edge(file_name, user_location):
+        Serves a file from the nearest edge server based on the user's location.
+Constants:
+    edge_servers (list): List of edge server names.
+    ROOT_CDN_DIR (str): Root directory for the CDN storage.
+"""
+import os
+import shutil
+
+edge_servers = ['edge1', 'edge2', 'edge3']
+
+ROOT_CDN_DIR = "cdn_storage"
+
+if not os.path.exists(ROOT_CDN_DIR):
+    os.makedirs(ROOT_CDN_DIR)
+
+def upload_to_origin(file_name, content):
+    """
+    Uploads a file to the origin server and replicates it to all edge servers.
+    Args:
+        file_name (str): The name of the file to upload.
+        content (str): The content of the file to upload.
+    Returns:
+        dict: A dictionary containing the result of the operation.
+    """
+    origin_path = os.path.join(ROOT_CDN_DIR, 'origin')
+    if not os.path.exists(origin_path):
+        os.makedirs(origin_path)
+    file_path = os.path.join(origin_path, file_name)
+    with open(file_path, 'w', encoding='utf-8') as f:
+        f.write(content)
+    replicate_result = replicate_to_edges(file_name)
+    return {"message": f"File {file_name} uploaded to origin. {replicate_result}"}
+
+def replicate_to_edges(file_name):
+    """
+    Replicates a file from the origin server to all edge servers.
+    Args:
+        file_name (str): The name of the file to replicate.
+    Returns:
+        dict: A dictionary containing the result of the operation.
+    """
+    origin_path = os.path.join(ROOT_CDN_DIR, 'origin', file_name)
+    if not os.path.exists(origin_path):
+        return {"error": "File does not exist in the origin."}
+    for server in edge_servers:
+        edge_dir = os.path.join(ROOT_CDN_DIR, server)
+        if not os.path.exists(edge_dir):
+            os.makedirs(edge_dir)
+        edge_path = os.path.join(edge_dir, file_name)
+        shutil.copy(origin_path, edge_path)
+    return {"message": f"File {file_name} replicated to all edge servers."}
+
+def serve_from_nearest_edge(file_name, user_location):
+    """
+    Serves a file from the nearest edge server based on the user's location.
+    Args:
+        file_name (str): The name of the file to serve.
+        user_location (int): The location of the user.
+    Returns:
+        dict: A dictionary containing the content of the file and the server it was served from.
+    """
+    nearest_server = edge_servers[user_location % len(edge_servers)]
+    edge_path = os.path.join(ROOT_CDN_DIR, nearest_server, file_name)
+    if os.path.exists(edge_path):
+        with open(edge_path, 'r', encoding='utf-8') as f:
+            return {"content": f.read(), "server": nearest_server}
+    else:
+        return {"error": f"File {file_name} not found."}


### PR DESCRIPTION
Added module that simulates a simple Content Delivery Network (CDN) with basic functionalities 
such as uploading files to the origin server, replicating files to edge servers, and 
serving files from the nearest edge server.