### PR TITLE
Add frontend and add delete functionality for CDN

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -20,7 +20,7 @@ Dependencies:
 from multiprocessing import Manager
 from flask import Flask, jsonify, request
 from vm_simulator import start_vm, stop_vm, monitor_vm, delete_vm, display_vms
-from cdn import upload_to_origin, serve_from_nearest_edge
+from cdn import upload_to_origin, delete_from_origin, serve_from_nearest_edge
 from storage import create_bucket, upload_file, delete_file, delete_bucket
 
 app = Flask(__name__)
@@ -160,8 +160,9 @@ def upload_to_origin_server(file_name):
     Returns:
         JSON response with the result of the operation.
     """
-    content = request.json.get('content')
-    result = upload_to_origin(file_name, content)
+    file = request.files['file']
+    file_content = file.read()
+    result = upload_to_origin(file_name, file_content)
     return jsonify(result)
 
 @app.route('/get_file/<file_name>/<int:user_location>', methods=['GET'])
@@ -175,6 +176,18 @@ def get_file_from_nearest_edge(file_name, user_location):
         JSON response with the content of the file and the server it was served from.
     """
     result = serve_from_nearest_edge(file_name, user_location)
+    return jsonify(result)
+
+@app.route('/delete_from_origin/<file_name>', methods=['DELETE'])
+def delete_from_origin_server(file_name):
+    """
+    Route to delete a file from the origin server and all edge servers.
+    Args:
+        file_name (str): The name of the file to delete.
+    Returns:
+        JSON response with the result of the operation.
+    """
+    result = delete_from_origin(file_name)
     return jsonify(result)
 
 if __name__ == '__main__':

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { BrowserRouter as Router, Route, Routes, Link } from 'react-router-dom';
 import VmManagement from './components/VmManagement';
 import StorageManagement from './components/StorageManagement';
+import CdnManagement from './components/CdnManagement';
 
 function App() {
   return (
@@ -20,12 +21,16 @@ function App() {
                 <Link to="/storage-management">
                   <button>Go to Storage Management</button>
                 </Link>
+                <Link to="/cdn-management">
+                  <button>Go to CDN Management</button>
+                </Link>
               </header>
             </div>
           }
         />
         <Route path="/vm-management" element={<VmManagement />} />
         <Route path="/storage-management" element={<StorageManagement />} />
+        <Route path="/cdn-management" element={<CdnManagement />} />
       </Routes>
     </Router>
   );

--- a/frontend/src/components/CdnManagement.js
+++ b/frontend/src/components/CdnManagement.js
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import '../styles/CdnManagement.css';
+
+function CdnManagement() {
+    const [fileName, setFileName] = useState('');
+    const [status, setStatus] = useState('');
+    const [userLocation, setUserLocation] = useState('');
+
+    const uploadToOrigin = () => {
+        const fileInput = document.getElementById('file');
+        if (!fileInput || !fileInput.files || fileInput.files.length === 0) {
+            setStatus('No file selected');
+            return;
+        }
+        const file = fileInput.files[0];
+        const formData = new FormData();
+        formData.append('file', file);
+        axios.post(`/upload_to_origin/${file.name}`, formData)
+            .then(response => setStatus(response.data.message))
+            .catch(error => setStatus(error.response.data.error));
+    };
+
+    const deleteFromOrigin = () => {
+        axios.delete(`/delete_from_origin/${fileName}`)
+            .then(response => setStatus(response.data.message))
+            .catch(error => setStatus(error.response.data.error));
+    };
+
+    const getFile = () => {
+        axios.get(`/get_file/${fileName}/${userLocation}`)
+            .then(response => {
+                const fileData = response.data;
+                if (fileData.message) {
+                    setStatus(response.data.message)
+                } else {
+                    const content = fileData.content;
+                    const server = fileData.server;
+                    setStatus(`
+                        <div>
+                            <h3>File Content:</h3>
+                            <pre>${content}</pre>
+                            <h3>Server:</h3>
+                            <p>${server}</p>
+                        </div>
+                    `);
+                }
+            })
+            .catch(error => setStatus(error.response.data.error));
+    };
+
+    return (
+        <div className="cdn-management-container">
+            <h2>CDN Management</h2>
+            <label>File: </label>
+            <input type="file" id="file" required />
+            <button onClick={uploadToOrigin}>Upload to Origin</button>
+            <input type="text" value={fileName} onChange={e => setFileName(e.target.value)} placeholder="Enter file name" required />
+            <input type="text" value={userLocation} onChange={e => setUserLocation(e.target.value)} placeholder="Enter user location" required />
+            <button onClick={getFile} disabled={!fileName || !userLocation}>Get File</button>
+            <button onClick={deleteFromOrigin} disabled={!fileName}>Delete from Origin</button>
+            <br />
+            <div className="status-message" dangerouslySetInnerHTML={{ __html: status }} />
+        </div>
+    );
+}
+
+export default CdnManagement;

--- a/frontend/src/styles/CdnManagement.css
+++ b/frontend/src/styles/CdnManagement.css
@@ -1,0 +1,59 @@
+.cdn-management-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 20px;
+    font-family: Arial, sans-serif;
+}
+
+.cdn-management-container h2 {
+    text-align: center;
+    margin-bottom: 20px;
+}
+
+.cdn-management-container label {
+    margin: 10px 0 5px 0;
+    font-weight: bold;
+}
+
+.cdn-management-container input[type="text"],
+.cdn-management-container input[type="file"] {
+    padding: 10px;
+    margin: 5px 0 15px 0;
+    width: 300px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 16px;
+}
+
+.cdn-management-container button {
+    padding: 10px 20px;
+    margin: 5px;
+    border: none;
+    border-radius: 4px;
+    background-color: #007bff;
+    color: white;
+    font-size: 16px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.cdn-management-container button:disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
+}
+
+.cdn-management-container button:hover:not(:disabled) {
+    background-color: #0056b3;
+}
+
+.cdn-management-container .status-message {
+    margin-top: 20px;
+    font-size: 18px;
+    color: #333;
+    text-align: center;
+}
+
+.cdn-management-container .status-message pre {
+    text-align: left;
+}


### PR DESCRIPTION
Added frontend for CDN

This commit also refactors the file upload logic in the backend app to use the `request.files` object instead of `request.json`. It also adds a new route `/delete_from_origin/<file_name>` to delete a file from the origin server and all edge servers.